### PR TITLE
Added NLP data set and ability to pull html DUA forms from SciAuthZ

### DIFF
--- a/app/dataprojects/fixtures/dataprojects.json
+++ b/app/dataprojects/fixtures/dataprojects.json
@@ -46,5 +46,17 @@
       "project_key": "SSC",
       "project_url": "https://ssc.hms.harvard.edu/transmart/datasetExplorer/index"
     }
+  },
+  {
+    "model": "dataprojects.dataproject",
+    "pk": 5,
+    "fields": {
+      "name": "i2b2 NLP Research Data Sets",
+      "institution": "Partners Healthcare",
+      "description": "<div>i2b2 is a passionate advocate for the potential of existing clinical information to yield insights that can directly impact healthcare improvement.  In our many use cases (Driving Biology Projects) it has become increasingly obvious that the value locked in unstructured text is essential to the success of our mission.  In order to enhance the ability of natural language processing (NLP) tools to prise increasingly fine grained information from clinical records, i2b2 has previously provided sets of fully deidentified notes from the Research Patient Data Repository at Partners HealthCare for a series of NLP Challenges organized by Dr. Ozlem Uzuner.  We are pleased to now make those notes available to the community for general research purposes. At this time we are releasing the notes (~1,500) from the first four i2b2 Challenges as i2b2 NLP Research Data Sets. A similar set of notes from the most recent i2b2 Challenge will be released on the one year anniversary of that Challenge. These data sets have already enabled hundreds of journal and conference articles by the research community.</div><br />",
+      "short_description": "Unstructured notes from the Research Patient Data Repository at Partners Healthcare.",
+      "project_key": "NLP",
+      "project_url": "https://www.i2b2.org/NLP/DataSets/Main.php"
+    }
   }
 ]

--- a/app/dataprojects/views.py
+++ b/app/dataprojects/views.py
@@ -44,6 +44,7 @@ def request_access(request, template_name='dataprojects/access_request.html'):
         dua_name = r.json()["results"][0]["dua"][0]["name"]
         dua = r.json()["results"][0]["permission_scheme"] == "PRIVATE"
         signatured_required = r.json()["results"][0]["dua_required"]
+        dua_form = r.json()["results"][0]["dua"][0]["agreement_form"]
     except:
         dua_text = ""
         dua_name = ""
@@ -54,6 +55,7 @@ def request_access(request, template_name='dataprojects/access_request.html'):
     return render(request, template_name, {"dua": dua,
                                            "signatured_required": signatured_required,
                                            "dua_text": dua_text,
+                                           "dua_form": dua_form,
                                            "project_key": request.POST['project_key'],
                                            "data_use_agreement": dua_name})
 
@@ -64,8 +66,11 @@ def submit_request(request, template_name='dataprojects/submit_request.html'):
     user_jwt = request.COOKIES.get("DBMI_JWT", None)
     jwt_headers = {"Authorization": "JWT " + user_jwt, 'Content-Type': 'application/json'}
 
-    data_request = {'project': request.POST['project_key'], 'user': request.user.email}
-    data_dua_sign = {'data_use_agreement': request.POST['data_use_agreement'], 'user': request.user.email}
+    data_request = {"project": request.POST['project_key'], "user": request.user.email}
+
+    data_dua_sign = {"data_use_agreement": request.POST['data_use_agreement'],
+                     "user": request.user.email,
+                     "agreement_text": request.POST['agreement_text']}
 
     create_auth_request_url = settings.CREATE_REQUEST_URL
     create_dua_sign_request_url = settings.CREATE_DUA_SIGN
@@ -110,8 +115,8 @@ def listDataprojects(request, template_name='dataprojects/list.html'):
             try:
                 for project_setup in r.json()["results"]:
                     for project in all_data_projects:
-                            if project.project_key == project_setup["project_key"]:
-                                project_permission_setup[project.project_key] = project_setup
+                        if project.project_key == project_setup["project_key"]:
+                            project_permission_setup[project.project_key] = project_setup
             except:
                 project_permission_setup = {}
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,7 +5,6 @@ django-stronghold==0.2.8
 djangorestframework==3.5.3
 djangorestframework-jwt==1.9.0
 django-smtp-ssl==1.0
-jwt==0.3.2
 mysqlclient==1.3.9
 py-auth0-jwt==0.2.5
 py-auth0-jwt-rest==0.1

--- a/app/templates/dataprojects/access_request.html
+++ b/app/templates/dataprojects/access_request.html
@@ -8,25 +8,33 @@
 <body>
 {% load static %}
 <form name="dua_access_form" action="/submit_request/" method="post">
+    {# TODO: IF NO DUA, WHAT INSTEAD? #}
+    <div id="agreement_form">
     {% if dua %}
-        {{ dua_text | safe }}
-    {% endif %}
+        {% if dua_form %}
+            {{ dua_form | safe }}
+        {% else %}
+            {{ dua_text | safe }}
 
-    {% if signatured_required%}
-        <br />
-        <br />
-        Typing your name in the box below signifies you agree with the terms of the Data Use Agreement
-        <br />
-        <br />
-        <input type="text" id="dua_name" class="form-control" />
+            {% if signatured_required%}
+                <br />
+                <br />
+                Typing your name in the box below signifies you agree with the terms of the Data Use Agreement
+                <br />
+                <br />
+                <input type="text" id="dua_signature" class="form-control" />
+            {% endif %}
+        {% endif %}
     {% endif %}
+    </div>
 
     <br />
     <br />
 
+    <input type="hidden" id="agreement_text" name="agreement_text" value="" />
     <input type="hidden" id="project_key" name="project_key" value="{{ project_key }}" />
     <input type="hidden" id="data_use_agreement" name="data_use_agreement" value="{{ data_use_agreement }}" />
-    <img name="loading" id="loading" src="{% static 'gears.svg' %}">
+    <img name="loading" id="loading" src="{% static 'gears.svg' %}" style="display:none;">
     <input name="submit_form" id="submit_form" type="submit" class="btn btn-default" value="Submit for approval" />
     <div id="status" style="color: green; font-size: 1.5em;"></div>
 
@@ -34,10 +42,17 @@
 </form>
 
 <script type="application/javascript">
-    $("#loading").hide();
     $('form[name=dua_access_form]').submit(function(){
 
         $("#loading").show();
+
+        // Replace each input field within the dua form with its value, so we have one complete dua form as a string
+        $(this).find("#agreement_form").find("input").each(function() {
+            $(this).replaceWith($(this).val());
+        });
+
+        // Move the content of the agreement_form block into the input in order to be captured by jQuery serialize
+        $("#agreement_text").val($("#agreement_form").text());
 
         $.post($(this).attr('action'), $(this).serialize(), function(res){
             $("#loading").hide();

--- a/app/templates/dataprojects/list.html
+++ b/app/templates/dataprojects/list.html
@@ -57,14 +57,6 @@
     }
 
     $( document ).ready(function() {
-        var $loading = $('#loadingDiv').hide();
-
-        $(document).ajaxStart(function () {
-            $loading.show();
-        }).ajaxStop(function () {
-            $loading.hide();
-        });
-
         $('.collapse').on('show.bs.collapse', function() {
             var icon = $( this ).closest('.panel-default' ).find( '.step-icon' )[0]
 


### PR DESCRIPTION
Added the NLP data set to the fixtures file.

Updated the SciAuthZ request functions to expect a field containing the DUA form (an html string). If we get back a form, we display that html which will contain input fields for the user to fill in. Once the user hits submit, the full DUA including the user's inputs will be collected and sent back to SciAuthZ to complete the request. Some jQuery code is used to replace the input fields with their values, allowing us to grab the completed DUA form as one long string.

Removed jwt package which is not needed and causes issues with the PyJWT package.

Note that in development you may need to add verify=False flags to all request  calls because the hostname on the certificate is not localhost.