### PR TITLE
Implemented DUA type switch

### DIFF
--- a/app/dataprojects/views.py
+++ b/app/dataprojects/views.py
@@ -39,26 +39,8 @@ def request_access(request, template_name='dataprojects/access_request.html'):
 
     r = request_project_access(request.COOKIES.get("DBMI_JWT", None), request.POST['project_key'])
 
-    try:
-        dua_text = r.json()["results"][0]["dua"][0]["agreement_text"]
-        dua_name = r.json()["results"][0]["dua"][0]["name"]
-        dua = r.json()["results"][0]["permission_scheme"] == "PRIVATE"
-        signatured_required = r.json()["results"][0]["dua_required"]
-        dua_form = r.json()["results"][0]["dua"][0]["agreement_form"]
-    except:
-        dua_text = ""
-        dua_name = ""
-        dua = True
-        signatured_required = True
-    # ------------------
-
-    return render(request, template_name, {"dua": dua,
-                                           "signatured_required": signatured_required,
-                                           "dua_text": dua_text,
-                                           "dua_form": dua_form,
-                                           "project_key": request.POST['project_key'],
-                                           "data_use_agreement": dua_name})
-
+    return render(request, template_name, {"dua_results": r.json()["results"][0],
+                                           "project_key": request.POST['project_key']})
 
 @user_auth_and_jwt
 def submit_request(request, template_name='dataprojects/submit_request.html'):

--- a/app/templates/dataprojects/access_request.html
+++ b/app/templates/dataprojects/access_request.html
@@ -8,51 +8,104 @@
 <body>
 {% load static %}
 <form name="dua_access_form" action="/submit_request/" method="post">
-    {# TODO: IF NO DUA, WHAT INSTEAD? #}
-    <div id="agreement_form">
-    {% if dua %}
-        {% if dua_form %}
-            {{ dua_form | safe }}
-        {% else %}
-            {{ dua_text | safe }}
-
-            {% if signatured_required%}
-                <br />
-                <br />
-                Typing your name in the box below signifies you agree with the terms of the Data Use Agreement
-                <br />
-                <br />
-                <input type="text" id="dua_signature" class="form-control" />
-            {% endif %}
-        {% endif %}
-    {% endif %}
-    </div>
-
-    <br />
-    <br />
-
     <input type="hidden" id="agreement_text" name="agreement_text" value="" />
     <input type="hidden" id="project_key" name="project_key" value="{{ project_key }}" />
-    <input type="hidden" id="data_use_agreement" name="data_use_agreement" value="{{ data_use_agreement }}" />
+    
+    {% if dua_results.permission_scheme == "PRIVATE" %}
+        
+        {# When there is more than one DUA form for this project, have the user select which form they will complete #}
+        {% if dua_results.dua|length > 1 %}
+            <div id="dua_form_selection">
+                <p>Select a form option:</p>
+                {% for agreement in dua_results.dua %}
+                    <button type="button" class="btn btn-primary dua_form_select" data-dua-form-name="{{ agreement.name }}">{{ agreement.name }}</button>            
+                {% endfor %}
+            </div>
+
+            <div id="dua_forms">
+            {# Initialize each form but hide them until the user has selected one to complete #}
+            {% for agreement in dua_results.dua %}
+                <div class="dua_form" data-dua-form-name="{{ agreement.name }}" style="display: none;">
+                    {{ agreement.agreement_form | safe }}
+                </div>
+            {% endfor %}
+            </div>
+
+            <input type="hidden" id="data_use_agreement" name="data_use_agreement" value="" />
+            <input name="submit_form" id="submit_form" type="submit" class="btn btn-default" style="display: none;" value="Submit for approval" />    
+        
+        {% elif dua_results.dua|length == 1 %}
+
+            <div class="dua_form" data-dua-form-name="{{ dua_results.dua.0.name }}">         
+            {# The DUA might be come in either as an HTML form or as plain text #}       
+            {% if dua_results.dua.0.agreement_form %}
+                {{ dua_results.dua.0.agreement_form | safe }}
+            {% else %}
+                {{ dua_results.dua.0.agreement_text | safe }}
+            
+                {% if dua_results.dua.0.dua_required %}
+                    <br />
+                    <br />
+                    Typing your name in the box below signifies you agree with the terms of the Data Use Agreement
+                    <br />
+                    <br />
+                    <input type="text" id="dua_signature" class="form-control" />
+                {% endif %}
+            {% endif %}
+            </div>
+
+            <input type="hidden" id="data_use_agreement" name="data_use_agreement" value="{{ dua_results.dua.0.name }}" />
+            <input name="submit_form" id="submit_form" type="submit" class="btn btn-default" value="Submit for approval" />    
+
+        {% else %}
+            Error: not implemented.
+        {% endif %}
+    
+    {% else %}
+        Error: this is not implemented.
+    {% endif %}
+    
     <img name="loading" id="loading" src="{% static 'gears.svg' %}" style="display:none;">
-    <input name="submit_form" id="submit_form" type="submit" class="btn btn-default" value="Submit for approval" />
     <div id="status" style="color: green; font-size: 1.5em;"></div>
 
     {% csrf_token %}
 </form>
 
 <script type="application/javascript">
+    // Display the DUA form if a user has selected one to complete
+    $('.dua_form_select').click(function() {
+        var dua_form_name = $(this).attr("data-dua-form-name");
+
+        // Set the data_use_agreement input value
+        $('#data_use_agreement').val(dua_form_name);
+        
+        // Display the form and submit button
+        $('.dua_form[data-dua-form-name="' + dua_form_name + '"]').show();
+        $('#submit_form').show();
+
+        // Hide the DUA form select buttons
+        $('#dua_form_selection').hide();
+    });
+</script>
+
+<script type="application/javascript">
     $('form[name=dua_access_form]').submit(function(){
 
         $("#loading").show();
 
+        // Get the name of the DUA form that was submitted
+        var dua_form_name = $('#data_use_agreement').val();
+
+        // Get the div element holding the DUA form
+        var dua_form = $(this).find(".dua_form[data-dua-form-name='" + dua_form_name + "']");
+
         // Replace each input field within the dua form with its value, so we have one complete dua form as a string
-        $(this).find("#agreement_form").find("input").each(function() {
+        dua_form.find("input").each(function() {
             $(this).replaceWith($(this).val());
         });
 
         // Move the content of the agreement_form block into the input in order to be captured by jQuery serialize
-        $("#agreement_text").val($("#agreement_form").text());
+        $("#agreement_text").val(dua_form.text());
 
         $.post($(this).attr('action'), $(this).serialize(), function(res){
             $("#loading").hide();


### PR DESCRIPTION
When requesting access to a project, SciAuthZ might return back a project with more than one Data Usage Agreement (DUA). To support this, I've moved logic to the front end to allow for the user to see which forms are available, select one, and then complete that form.