### PR TITLE
TC-96: enable logic with agreement forms and convert special inputs i…

### DIFF
--- a/app/media/agreementforms/c757e275-486f-4c3d-ab52-e295ccb8f45a.html
+++ b/app/media/agreementforms/c757e275-486f-4c3d-ab52-e295ccb8f45a.html
@@ -1,83 +1,148 @@
-<strong>2018 n2c2 Challenge Data Use and Confidentiality Agreement</strong><br>
-<br>
-Partners HealthCare System, Inc. on behalf of itself and its afﬁliates (collectively, "Partners") controls certain patient-level data, in the form of patient discharge summaries, from its clinical information systems, which have been de-identiﬁed within the meaning of the HIPAA Privacy Rule (the "Data"). Partners wishes to make the Data, in the form of one or more "Datasets", available to eligible registrants in connection with the National NLP Clinical Challenges (n2c2) Shared task and Workshop (the "Shared task"). Partners is making the Data available solely for the purpose of enabling registrants to conduct research (the "Purpose").<br>
-<br>
-This Data Use and Conﬁdentiality Agreement explains the terms and conditions of access to the Data by registrants in the Shared task. ANY REGISTRANT WHO WISHES TO ACCESS THE DATA MUST READ THE FOLLOWING TERMS AND AGREE TO THEM BY ENTERING THE INFORMATION REQUESTED BELOW.<br>
-<br>
-<strong>TERMS AND CONDITIONS</strong><br>
-1.	Registrant understands and agrees that any Data / Datasets that Partners provides to Registrant are proprietary and conﬁdential to Partners.<br>
-2.	Registrant agrees that Registrant will use the Data / Datasets solely for research and for no other purpose.<br>
-3.	Registrant agrees that Registrant will not attempt to identify or re-identify any individual patient or group of patients from the Data / Datasets.<br>
-4.	Registrant agrees that Registrant will not disclose, disseminate, or otherwise share the Data / Datasets to or with any other person or entity except with persons or entities on Registrant's Shared task team, each of which persons/entities Registrant will inform of the obligations with respect to use and confidentiality of the Data under this Agreement. Registrant shall be responsible for compliance by these persons/entities with the terms of this Agreement and any breach thereof.<br>
-5.	Registrant agrees not to use the name or logo of Partners or any of its afﬁliates or any of their respective trustees, directors, officers, staff members, employees, students or agents for any purpose without Partners' prior written approval excepting in the course of presentation and or publication deriving from the Shared task wherein the data source is acknowledged.<br>
-6.	All Data / Datasets disclosed pursuant to this Agreement, including without limitation all written and tangible forms thereof, shall be and remain the property of Partners. Upon completion of the Shared task or earlier termination of the Agreement as provided in Section 8 below, Registrant shall cease using the Data / Datasets and shall destroy (or return if so requested by Partners) all of the Data / Datasets received in tangible form, including notes, reports, and other information incorporating the Data / Datasets, and shall keep no copies, except to the extent speciﬁcally required by law(s) made know to Partners by Registrant.<br>
-7.	Registrant understands and agrees that Partners may use and further share with third parties any Data / Datasets that have been annotated or otherwise enhanced or modiﬁed by Registrant in connection with its participation in the Shared task ("Annotated Data / Datasets") for the purpose of conducting or enabling such third parties to conduct research and development of Natural Language Processing tools and analytics. [Registrant shall not be entitled to any compensation in connection with such use of the Annotated Data / Datasets.]<br>
-8.	Partners may terminate Registrant's access to Data / Datasets under this Agreement for any reason upon written notice to Registrant.<br>
-9.	Registrant's obligations under this Agreement shall survive the expiration or termination of the Agreement.<br>
-10.	Registrant acknowledges that any use or disclosure of the Data / Datasets that is inconsistent with the terms of this Agreement may cause irreparable injury to Partners and agrees that Partners will be entitled to seek injunctive relief with respect to such use and/or disclosure, in addition to seeking any other remedy available at law or in equity.<br>
-11.	This Agreement may be modiﬁed or amended only in a writing signed by duly authorized representatives of both Registrant and Partners. This Agreement shall be governed by and construed in accordance with the laws of the Commonwealth of Massachusetts. Any claim or action brought under this Agreement shall be brought in the federal or state courts of Massachusetts.<br>
-_____________________________________________________<br>
-<br>
-<strong>REGISTRANT INFORMATION</strong><br>
-<strong>Registrant is either</strong> (select one):<br>
-<input type="checkbox" name="is-individual"/> an individual or academic organization, requesting Data under this Agreement on behalf of<br>
-himself/herself or the academic organization<br>
-<input type="checkbox" name="is-corporation"/> a corporation, requesting Data under this Agreement on behalf of itself and its agents and<br>
-employees<br>
-<br>
-<b><i>If individual/academic</i></b><br>
-Name  <input type="text" name="person-name" size="40"/>* <br>
-Professional Title  <input type="text" name="professional-title" size="40"/>*	<br>
-Institution or Organization  <input type="text" name="institution" size="40"/>*	<br>
-Street address  <input type="text" name="address" size="40"/>*	<br>
-City  <input type="text" name="city" size="40"/>*	<br>
-State <input type="text" name="state" size="2"/>*	<br>
-Zip  <input type="text" name="zip" size="6"/>*	<br>
-Country <input type="text" name="country" size="40"/><br>
-Phone  <input type="text" name="person-phone" size="40"/>*	<br>
-E-mail  <input type="text" name="person-email" size="40"/>*<br>
-<br>
-<b><i>If corporation</i></b><br>
-Principal Place of Business  <input type="text" name="place-of-business" size="40"/>*<br>
-Contact Name/Title  <input type="text" name="contact-name" size="40"/>*	<br>
-Phone  <input type="text" name="business-phone" size="40"/>*	<br>
-E-mail  <input type="text" name="business-email" size="40"/>*	<br>
-<br>
-_____________________________________________________<br>
-<br>
-<b>TEAM STATUS</b><br>
-<b>Registrant is either</b> (select one):<br>
-<input type="checkbox" name="is-team"/> a team member (non-principal investigator)<br>
-<input type="checkbox" name="is-principal-no-team"/> a principal investigator with no team members<br>
-<input type="checkbox" name="is-principal-with-team"/> a principal investigator (team leader) with team members.<br>
-<br>
-<b>Principal Investigators (Team Leaders) are required to list all of their team members.</b></b><br>
-<br>
-**Team Member List**<br>
-<br>
-Team Member #1<br>
-Full Name  <input type="text" name="member1-name" size="40"/>*<br>
-Email  <input type="text" name="member1-email" size="40"/>*<br>
-<br>
-Team Member #2<br>
-Full Name  <input type="text" name="member2-name" size="40"/><br>
-Email  <input type="text" name="member2-email" size="40"/><br>
-<br>
-Team Member #3<br>
-Full Name  <input type="text" name="member3-name" size="40"/><br>
-Email  <input type="text" name="member3-email" size="40"/><br>
-<br>
-Team Member #4<br>
-Full Name  <input type="text" name="member4-name" size="40"/><br>
-Email  <input type="text" name="member4-email" size="40"/><br>
-<br>
-______________________________________________________________________________________<br>
-<br>
-<b>BY ENTERING THE INFORMATION REQUESTED IN THIS AGREEMENT AS DIRECTED ABOVE, REGISTRANT AFFIRMS THAT REGISTRANT HAS READ THE TERMS AND CONDITIONS OF ACCESS TO DATA FOR THE COMPETITION AND AGREES TO THEM.</b><br>
-<br>
-<b>REGISTRANT</b><br>
-Electronic Signature (Full Name)  <input type="text" name="electronic-signature" size="40"/>*	<br>
-Professional Title  <input type="text" name="professional-title" size="40"/>*	<br>
-Date  <input type="date" name="date" size="40"/>*	 <br>
-Principal Investigator (Team Leader)  <input type="text" name="principal-investigator-name" size="40"/>*	<br>
-<input type="checkbox" name="i-agree"/> I agree to the terms and conditions above. By clicking the "I Agree" checkbox I certify that this is my legal signature.<br>
+<div class="form-content">
+    <h4>2018 n2c2 Challenge Data Use and Confidentiality Agreement</h4>
+
+    <p>Partners HealthCare System, Inc. on behalf of itself and its afﬁliates (collectively, "Partners") controls certain patient-level data, in the form of patient discharge summaries, from its clinical information systems, which have been de-identiﬁed within the meaning of the HIPAA Privacy Rule (the "Data"). Partners wishes to make the Data, in the form of one or more "Datasets", available to eligible registrants in connection with the National NLP Clinical Challenges (n2c2) Shared task and Workshop (the "Shared task"). Partners is making the Data available solely for the purpose of enabling registrants to conduct research (the "Purpose").</p>
+
+    <p>This Data Use and Conﬁdentiality Agreement explains the terms and conditions of access to the Data by registrants in the Shared task. ANY REGISTRANT WHO WISHES TO ACCESS THE DATA MUST READ THE FOLLOWING TERMS AND AGREE TO THEM BY ENTERING THE INFORMATION REQUESTED BELOW.</p>
+
+    <h5>TERMS AND CONDITIONS</h5>
+
+    <p>1. Registrant understands and agrees that any Data / Datasets that Partners provides to Registrant are proprietary and conﬁdential to Partners.</p>
+    <p>2. Registrant agrees that Registrant will use the Data / Datasets solely for research and for no other purpose.</p>
+    <p>3. Registrant agrees that Registrant will not attempt to identify or re-identify any individual patient or group of patients from the Data / Datasets.</p>
+    <p>4. Registrant agrees that Registrant will not disclose, disseminate, or otherwise share the Data / Datasets to or with any other person or entity except with persons or entities on Registrant's Shared task team, each of which persons/entities Registrant will inform of the obligations with respect to use and confidentiality of the Data under this Agreement. Registrant shall be responsible for compliance by these persons/entities with the terms of this Agreement and any breach thereof.</p>
+    <p>5. Registrant agrees not to use the name or logo of Partners or any of its afﬁliates or any of their respective trustees, directors, officers, staff members, employees, students or agents for any purpose without Partners' prior written approval excepting in the course of presentation and or publication deriving from the Shared task wherein the data source is acknowledged.</p>
+    <p>6. All Data / Datasets disclosed pursuant to this Agreement, including without limitation all written and tangible forms thereof, shall be and remain the property of Partners. Upon completion of the Shared task or earlier termination of the Agreement as provided in Section 8 below, Registrant shall cease using the Data / Datasets and shall destroy (or return if so requested by Partners) all of the Data / Datasets received in tangible form, including notes, reports, and other information incorporating the Data / Datasets, and shall keep no copies, except to the extent speciﬁcally required by law(s) made know to Partners by Registrant.</p>
+    <p>7. Registrant understands and agrees that Partners may use and further share with third parties any Data / Datasets that have been annotated or otherwise enhanced or modiﬁed by Registrant in connection with its participation in the Shared task ("Annotated Data / Datasets") for the purpose of conducting or enabling such third parties to conduct research and development of Natural Language Processing tools and analytics. [Registrant shall not be entitled to any compensation in connection with such use of the Annotated Data / Datasets.]</p>
+    <p>8. Partners may terminate Registrant's access to Data / Datasets under this Agreement for any reason upon written notice to Registrant.</p>
+    <p>9. Registrant's obligations under this Agreement shall survive the expiration or termination of the Agreement.</p>
+    <p>10. Registrant acknowledges that any use or disclosure of the Data / Datasets that is inconsistent with the terms of this Agreement may cause irreparable injury to Partners and agrees that Partners will be entitled to seek injunctive relief with respect to such use and/or disclosure, in addition to seeking any other remedy available at law or in equity.</p>
+    <p>11. This Agreement may be modiﬁed or amended only in a writing signed by duly authorized representatives of both Registrant and Partners. This Agreement shall be governed by and construed in accordance with the laws of the Commonwealth of Massachusetts. Any claim or action brought under this Agreement shall be brought in the federal or state courts of Massachusetts.</p>
+
+    <hr>
+
+    <h5>REGISTRANT INFORMATION</h5>
+
+    <h6>Registrant is either (select one):</h6>
+
+    <div class="radio" id="registrant-is">
+        <label>
+            <input type="radio" name="registrant-is" value="individual">
+            an individual or academic organization, requesting Data under this Agreement on behalf of himself/herself or the academic organization<br>
+        </label>
+        <label>
+            <input type="radio" name="registrant-is" value="corporation">
+            a corporation, requesting Data under this Agreement on behalf of itself and its agents and employees
+        </label>
+    </div>
+
+    <div id="academic-questions" style="display: none">
+        <h6>Individual/Academic</h6>
+
+        <div class="form-group">
+            <label for="person-name">Name</label>
+            <input type="text" class="form-control" id="person-name">
+        </div>
+        <div class="form-group">
+            <label for="professional-title">Professional Title</label>
+            <input type="text" class="form-control" id="professional-title">
+        </div>
+        <div class="form-group">
+            <label for="institution">Institution or Organization</label>
+            <input type="text" class="form-control" id="institution">
+        </div>
+        <div class="form-group">
+            <label for="address">Street Address</label>
+            <input type="text" class="form-control" id="address">
+        </div>
+        <div class="form-group">
+            <label for="city">City</label>
+            <input type="text" class="form-control" id="city">
+        </div>
+        <div class="form-group">
+            <label for="state">State</label>
+            <input type="text" class="form-control" id="state">
+        </div>
+        <div class="form-group">
+            <label for="zip">Zip</label>
+            <input type="text" class="form-control" id="zip">
+        </div>
+        <div class="form-group">
+            <label for="country">Country</label>
+            <input type="text" class="form-control" id="country">
+        </div>
+        <div class="form-group">
+            <label for="person-phone">Phone</label>
+            <input type="text" class="form-control" id="person-phone">
+        </div>
+        <div class="form-group">
+            <label for="person-email">E-mail</label>
+            <input type="text" class="form-control" id="person-email">
+        </div>
+    </div>
+
+    <div id="corporation-questions" style="display: none">
+        <h6>Corporation</h6>
+
+        <div class="form-group">
+            <label for="place-of-business">Principal Place of Business</label>
+            <input type="text" class="form-control" id="place-of-business">
+        </div>
+        <div class="form-group">
+            <label for="contact-name">Contact Name/Title</label>
+            <input type="text" class="form-control" id="contact-name">
+        </div>
+        <div class="form-group">
+            <label for="business-phone">Phone</label>
+            <input type="text" class="form-control" id="business-phone">
+        </div>
+        <div class="form-group">
+            <label for="business-email">E-mail</label>
+            <input type="text" class="form-control" id="business-email">
+        </div>
+    </div>
+
+    <hr>
+
+    <p>BY ENTERING THE INFORMATION REQUESTED IN THIS AGREEMENT AS DIRECTED ABOVE, REGISTRANT AFFIRMS THAT REGISTRANT HAS READ THE TERMS AND CONDITIONS OF ACCESS TO DATA FOR THE COMPETITION AND AGREES TO THEM.</p>
+
+    <div class="form-group">
+        <label for="electronic-signature">Electronic Signature (Full Name)</label>
+        <input type="text" class="form-control" id="electronic-signature">
+    </div>
+    <div class="form-group">
+        <label for="professional-title">Professional Title</label>
+        <input type="text" class="form-control" id="professional-title">
+    </div>
+    <div class="form-group">
+        <label for="date">Date</label>
+        <input type="date" class="form-control" id="date">
+    </div>
+    <div class="form-group">
+        <label for="principal-investigator-name">Principal Investigator (Team Leader)</label>
+        <input type="text" class="form-control" id="principal-investigator-name">
+    </div>
+
+    <label class="checkbox-inline">
+        <input type="checkbox" id="i-agree" value="Yes"> I agree to the terms and conditions above. By clicking the "I Agree" checkbox I certify that this is my legal signature.
+    </label>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        // When someone clicks what kind of registrant they are, hide the opposite form section
+        $('#registrant-is').change(function() {
+            var selected_value = $("input[name='registrant-is']:checked").val();
+            
+            if (selected_value == "individual") {
+                $('#academic-questions').show();
+                $('#corporation-questions').show();
+            }
+
+            if (selected_value == "corporation") {
+                $('#academic-questions').hide();
+                $('#corporation-questions').show();
+            }
+        });
+    });
+</script>

--- a/app/media/agreementforms/e3b33c4d-94d2-4738-9d4c-308548943435.html
+++ b/app/media/agreementforms/e3b33c4d-94d2-4738-9d4c-308548943435.html
@@ -1,26 +1,53 @@
-<strong>2018 National NLP Clinical Challenges (n2c2) Shared Task and Workshop</strong><br>
-<br>
-<strong>Rules of Conduct</strong><br>
-<br>
-The format of the 2018 n2c2 shared task and the principles which bind the participants of this shared task are as follows:<br>
-1.	In order to support the shared task, n2c2 will provide the participants with data from Partners Healthcare.<br>
-2.	The data will be distributed with a data use agreement.<br>
-3.	All members of all teams are required to sign the data use agreement online.<br>
-4.	n2c2 will ﬁrst release annotated training data. Teams can use this data to develop their systems. The systems are expected to be fully automatic, i.e., no human intervention in their output.<br>
-5.	Evaluation is to be run on held-out test data. Teams are not allowed to train on test data. All development and training must stop before teams download the test data. Teams are expected to generate fully automatic system outputs on the test data. Manual interventions with the test data predictions are not acceptable.<br>
-6.	Gaining access to any portion of the 2018 n2c2 data commits the teams to participate in the evaluation that will be run by n2c2. <b>Teams cannot withdraw from the evaluation after gaining access to the data.</b><br>
-7.	Gaining access to any portion of the 2018 n2c2 data commits the teams to submit a paper describing their developed system to n2c2.<br>
-8.	Gaining access to any portion of the 2018 n2c2 data commits the teams to present their work in the follow-up workshop to be organized by n2c2 (should their submitted paper be accepted for presentation).<br>
-9.	In return for following through with the commitments outlined in the previous three items, the teams can conduct research and publish papers on the released data one year before anyone else. The 2018 n2c2 data will only be available to the research community-at-large one year after the evaluation so that shared-task participants have ample time to publish their work on the shared-task data.<br>
-<br>
-I have read and understood the 2018 n2c2 Shared Task Challenge and Workshop Rules of Conduct. <br>
-Name <input type="text" name="person-name" size="40"/>*<br>
-Email  <input type="text" name="email" size="40"/>*<br>
-Organization/Institution  <input type="text" name="organization" size="40"/>*<br>
-E-signature (full name)  <input type="text" name="esignature" size="40"/>*<br>
-Professional Title  <input type="text" name="professional-title" size="40"/>*<br>
-Date  <input type="date" name="date" size="40"/>*<br>
-Principal Investigator (Team Leader)  <input type="text" name="principal-investigator" size="40"/>*<br>
-<input type="checkbox" name="i-agree" size="40"/> I agree to the terms and conditions above. By clicking the "I Agree" checkbox I certify that this is my legal signature.<br>
-<br>
-*Required field
+<div class="form-content">
+    <h4>2018 National NLP Clinical Challenges (n2c2) Shared Task and Workshop</h4>
+
+    <h5>Rules of Conduct</h5>
+
+    <p>The format of the 2018 n2c2 shared task and the principles which bind the participants of this shared task are as follows:</p>
+    <p>1. In order to support the shared task, n2c2 will provide the participants with data from Partners Healthcare.</p>
+    <p>2. The data will be distributed with a data use agreement.</p>
+    <p>3. All members of all teams are required to sign the data use agreement online.</p>
+    <p>4. n2c2 will ﬁrst release annotated training data. Teams can use this data to develop their systems. The systems are expected to be fully automatic, i.e., no human intervention in their output.</p>
+    <p>5. Evaluation is to be run on held-out test data. Teams are not allowed to train on test data. All development and training must stop before teams download the test data. Teams are expected to generate fully automatic system outputs on the test data. Manual interventions with the test data predictions are not acceptable.</p>
+    <p>6. Gaining access to any portion of the 2018 n2c2 data commits the teams to participate in the evaluation that will be run by n2c2. Teams cannot withdraw from the evaluation after gaining access to the data.</p>
+    <p>7. Gaining access to any portion of the 2018 n2c2 data commits the teams to submit a paper describing their developed system to n2c2.</p>
+    <p>8. Gaining access to any portion of the 2018 n2c2 data commits the teams to present their work in the follow-up workshop to be organized by n2c2 (should their submitted paper be accepted for presentation).</p>
+    <p>9. In return for following through with the commitments outlined in the previous three items, the teams can conduct research and publish papers on the released data one year before anyone else. The 2018 n2c2 data will only be available to the research community-at-large one year after the evaluation so that shared-task participants have ample time to publish their work on the shared-task data.</p>
+
+    <hr>
+
+    <p>I have read and understood the 2018 n2c2 Shared Task Challenge and Workshop Rules of Conduct.</p>
+
+    <div class="form-group">
+        <label for="person-name">Name</label>
+        <input type="text" class="form-control" id="person-name">
+    </div>
+    <div class="form-group">
+        <label for="email">Email</label>
+        <input type="text" class="form-control" id="email">
+    </div>
+    <div class="form-group">
+        <label for="organization">Organization/Institution</label>
+        <input type="text" class="form-control" id="organization">
+    </div>
+    <div class="form-group">
+        <label for="e-signature">E-signature (full name)</label>
+        <input type="text" class="form-control" id="e-signature">
+    </div>
+    <div class="form-group">
+        <label for="professional-title">Professional Title</label>
+        <input type="text" class="form-control" id="professional-title">
+    </div>
+    <div class="form-group">
+        <label for="date">Date</label>
+        <input type="date" class="form-control" id="date">
+    </div>
+    <div class="form-group">
+        <label for="principal-investigator">Principal Investigator (Team Leader)</label>
+        <input type="text" class="form-control" id="principal-investigator">
+    </div>
+
+    <label class="checkbox-inline">
+        <input type="checkbox" id="i-agree" value="Yes"> I agree to the terms and conditions above. By clicking the "I Agree" checkbox I certify that this is my legal signature.
+    </label>
+</div>

--- a/app/templates/project_details.html
+++ b/app/templates/project_details.html
@@ -106,8 +106,10 @@
                             <input type="hidden" class="agreement_form_id" name="agreement_form_id" value="{{ agreement_form.agreement_form_id }}" />
                             <input type="hidden" class="agreement_text" name="agreement_text" value="" />
     
+                            <hr>
+
                             <div class="submit_form">
-                                <input name="submit_form" type="submit" class="btn btn-primary" value="Submit for approval" />
+                                <input name="submit_form" type="submit" class="btn btn-primary" value="Submit" />
                             </div>
 
                             {% csrf_token %}
@@ -177,12 +179,24 @@
     $('form[name=agreement_form_container]').submit(function(e){
         e.preventDefault();
 
-        // Grab the div element holding the agreement form and the user's inputs
-        var agreement_form_contents = $(this).find(".agreement_form_contents");
+        // Grab the div element holding the agreement form and the user's inputs. The form file should have
+        // wrapped in a <div class="form-content"> all the form except for any JavaScript so that no JS gets
+        // included in the saved form string.
+        var agreement_form_contents = $(this).find(".agreement_form_contents").find(".form-content");
 
         // Replace each input field within the form with its value, so we have one complete agreement form as a string
         agreement_form_contents.find("input").each(function() {
-            $(this).replaceWith($(this).val());
+
+            // For a radio or checkbox, checked inputs should turn into X's
+            if ($(this).is(':radio') || $(this).is(':checkbox')) {
+                if ($(this).is(':checked')) {
+                    $(this).replaceWith("[X]");
+                } else {
+                    $(this).replaceWith("[ ]");
+                }
+            } else {
+                $(this).replaceWith($(this).val());
+            }
         });
 
         // Find the div element where we want to paste the string containing the completed form


### PR DESCRIPTION
…nto text

Cleaned up N2C2 ROC and DUA to use bootstrap design and JavaScript where appropriate. Special inputs like radio buttons and checkboxes will now get saved with an "[X]" or "[ ]" depending on if checked.