### PR TITLE
TC-130: Remove PI drop down and force user to enter an email address

### DIFF
--- a/app/projects/urls.py
+++ b/app/projects/urls.py
@@ -10,7 +10,8 @@ from .views import project_details
 from .views import signout
 from .views import view_team_management
 from .views_teams import join_team
-from .views_teams import create_team_from_pi
+from .views_teams import leave_team
+from .views_teams import create_team
 from .views_teams import team_signup_form
 from .views_teams import approve_team_join
 from .views_teams import reject_team_join
@@ -29,9 +30,10 @@ urlpatterns = (
     url(r'^save_signed_agreement_form', save_signed_agreement_form),
     url(r'^signout/$', signout),
     url(r'^join_team/$', join_team),
+    url(r'^leave_team/$', leave_team),
     url(r'^approve_team_join/$', approve_team_join),
     url(r'^reject_team_join/$', reject_team_join),
-    url(r'^create_team_from_pi/$', create_team_from_pi),
+    url(r'^create_team/$', create_team),
     url(r'^finalize_team/$', finalize_team),
     url(r'^activate_team/$', activate_team),
     url(r'^deactivate_team/$', deactivate_team),

--- a/app/projects/views.py
+++ b/app/projects/views.py
@@ -354,7 +354,6 @@ def project_details(request, project_key, template_name='project_details.html'):
     registration_form = None
     agreement_forms_list = []
     participant = None
-    all_teams = None
     is_manager = False
     user_requested_access = False
     user_access_request_granted = False
@@ -448,11 +447,6 @@ def project_details(request, project_key, template_name='project_details.html'):
             team_has_pending_members = team_members.filter(team_approved=False)
             user_is_team_leader = team.team_leader == request.user
 
-        try:
-            all_teams = Team.objects.filter(data_project__project_key=project_key)
-        except ObjectDoesNotExist:
-            all_teams = None
-
         # If all other steps completed, then last step will be team
         if current_step is None:
             current_step = "team"
@@ -473,7 +467,6 @@ def project_details(request, project_key, template_name='project_details.html'):
     return render(request, template_name, {"project": project,
                                            "agreement_forms_list": agreement_forms_list,
                                            "participant": participant,
-                                           "all_teams": all_teams,
                                            "team": team,
                                            "user_is_team_leader": user_is_team_leader,
                                            "team_members": team_members,

--- a/app/templates/datacontests/managecontests.html
+++ b/app/templates/datacontests/managecontests.html
@@ -35,12 +35,13 @@
                             {% if team.status == "Pending" %}
                                 Pending
                             {% elif team.status == "Ready" %}
-                                <span class="label label-success">Ready to Activate</span></td>
+                                <span class="label label-success">Ready to Activate</span>
                             {% elif team.status == "Active" %}
                                 Active
                             {% elif team.status == "Deactivated" %}
                                 Deactivated
                             {% endif %}
+                            </td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/app/templates/datacontests/teamdetails.html
+++ b/app/templates/datacontests/teamdetails.html
@@ -59,7 +59,16 @@
     {% endif %}
 {% else %}
     {% if participant.team_wait_on_leader %}
-        No action needed at this time. We are waiting for your team leader {{ participant.team_wait_on_leader_email }} to create a team.
+        <p>No action needed at this time. We are waiting for your team leader <span class="label label-default">{{ participant.team_wait_on_leader_email }}</span> to create a team and approve your access. </p>
+        <hr>
+        <p>Is your team leader using a different email address? Click the button below to return to the team join step.</p>
+
+        <form action="/projects/leave_team/" method="post">
+            {% csrf_token %}
+            <input name="project_key" type="hidden" value="{{ project.project_key }}"/>
+            <button class="btn btn-default btn-sm" type="submit">Restart Team Setup</button>
+        </form>
+
     {%  elif participant.team_pending %}
         No action needed at this time. We are waiting for your team leader {{ team.team_leader }} to approve your request to join the team.
     {%  elif participant.team_approved %}
@@ -68,60 +77,56 @@
         </div>
     {% else %}
         <div class="alert alert-warning" role="alert">
-            You have not yet joined a team. Please either select your team leader from the list below or enter their email to wait for them to create a team. If you are the team leader, please click the Create Team button.
+            You have not yet joined a team. Please either join a team or create one. To join an existing team, enter the email address of your team leader. To create a team as its team leader, please click the Create Team button below. <strong>Note: student participants must have at least one faculty member on their team, and the faculty member should be the team leader.</strong>
         </div>
 
-        <form action="/projects/join_team/" method="post">
-            {% csrf_token %}
-            <div class="form-group">
-                <label for="team_list">Current team leader list:</label>
-                <select class="form-control" name="existing_pi_team_to_join">
-                    {% for team in all_teams %}
-                    <option value="{{ team }}">{{ team }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+        <div class="row">
+            <div class="col-md-8">
+                <h4>Joining a team?</h4>
 
-            <strong>Don't see your team leader?</strong>
-            <p>They might not have registered yet. Enter their e-mail address below and you'll be added to the team when they register. </p>
-            
-            <input class="form-control" type="email" name="pi_to_wait_for" />
-            
-            <div class="form-group">
-                <input name="project_key" type="hidden" value="{{ project.project_key }}"/>
-            </div>
-            <button class="btn btn-primary" type="submit">Join Team</button>
-        </form>
-
-        <hr>
-
-        <h4>Are you leading a team?</h4>
-
-        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#new_pi_modal">Create Team</button>
-
-        <div class="modal fade" id="new_pi_modal" tabindex="-1" role="dialog" aria-labelledby="new_pi_modalLabel" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="new_pi_modalLabel">Create Team Confirmation</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-            Are you sure you want to create a new team and become the team leader for that team?
-            </div>
-            <div class="modal-footer">
-                <form action="/projects/create_team_from_pi/" method="post">
+                <form action="/projects/join_team/" method="post">
                     {% csrf_token %}
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
 
                     <input name="project_key" type="hidden" value="{{ project.project_key }}"/>
-                    <button type="submit" class="btn btn-primary">Sign me up!</button>
+
+                    <div class="input-group">
+                        <input class="form-control" type="email" name="team_leader" placeholder="Team leader's email..." required/>
+                        <span class="input-group-btn">
+                            <button class="btn btn-primary" type="submit">Join Team</button>
+                        </span>
+                    </div>
                 </form>
             </div>
+            
+            <div class="col-md-4">
+                <h4>Leading a team?</h4>
+                <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#new_team_modal">Create Team</button>
             </div>
         </div>
+
+        <div class="modal fade" id="new_team_modal" tabindex="-1" role="dialog" aria-labelledby="new_team_modalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="new_team_modalLabel">Create Team Confirmation</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        Are you sure you want to create a new team and become its team leader?
+                    </div>
+                    <div class="modal-footer">
+                        <form action="/projects/create_team/" method="post">
+                            {% csrf_token %}
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+
+                            <input name="project_key" type="hidden" value="{{ project.project_key }}"/>
+                            <button type="submit" class="btn btn-primary">Sign me up!</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
         </div>
     {% endif %}
 {% endif %}

--- a/app/templates/project_details.html
+++ b/app/templates/project_details.html
@@ -32,11 +32,11 @@
 
     <div class="col-md-6">
     {% if not user_logged_in %}
-        <div class="alert alert-danger alert-dismissible" role="alert">
+        <div class="alert alert-danger" role="alert">
             To compete in {{ project.short_description }} please first <a href="{{ request.build_absolute_uri|get_login_url }}">login or register</a>.
         </div>
     {% elif not access_granted %}    
-        <div class="alert alert-warning alert-dismissible" role="alert">
+        <div class="alert alert-info" role="alert">
             To compete in {{ project.short_description }}, please complete the registration process below one step at a time. <strong>All members of your team must complete all registration steps before your account can be activated.</strong>
         </div>
         


### PR DESCRIPTION
Users now must enter the team leader's email address and wait to be granted access. Users can now also reset their team status back to empty if they entered the email incorrectly.