### PR TITLE
TC-170: Fixes bug where team rows not loaded at first are not clickable

### DIFF
--- a/app/templates/datacontests/managecontests.html
+++ b/app/templates/datacontests/managecontests.html
@@ -145,7 +145,7 @@
 <script type="application/javascript">
     // When clicking a team row, open a new window for team managment
     $(document).ready(function() {
-        $('.team-row').click(function() {
+        $('#team-table').on("click", ".team-row", function() {
             var team = $(this).data('team');
             window.open("./" + team);
         });


### PR DESCRIPTION
This is because the DataTable does not load all rows into DOM at first.