### PR TITLE
TC-208: Remove media from collectstatic

### DIFF
--- a/app/hypatio/settings.py
+++ b/app/hypatio/settings.py
@@ -191,7 +191,6 @@ STATIC_URL = '/static/'
 # THIS IS WHERE FILES ARE COLLECTED FROM
 STATICFILES_DIRS = (
     normpath(join(DJANGO_ROOT, 'static')),
-    normpath(join(DJANGO_ROOT, 'media'))
 )
 
 STATICFILES_FINDERS = (


### PR DESCRIPTION
Media folder contents do not need to be pushed to static anymore. This reduces security risks too.