### PR TITLE
HYP-43: Fixes default date for ROC form on Safari

### DIFF
--- a/app/static/agreementforms/n2c2-t1_roc.html
+++ b/app/static/agreementforms/n2c2-t1_roc.html
@@ -51,7 +51,7 @@
 <script type="application/javascript">
     // Default to today's date
     $(document).ready(function(){
-        var today = new Date();
-        document.getElementById("date").valueAsDate = today;
+        var today = $.datepicker.formatDate('yy-mm-dd', new Date());
+        $('#date').val(today);
     });
 </script>


### PR DESCRIPTION
Safari did not support original way we were setting the date field.