### PR TITLE
HYP-80: Fixes a migration file bug regarding an unknown column

### DIFF
--- a/app/hypatio/sciauthz_services.py
+++ b/app/hypatio/sciauthz_services.py
@@ -60,12 +60,14 @@ class SciAuthZ:
     def current_user_permissions(self):
 
         try:
+            # TODO Do you need to specify email here?
             user_permissions = requests.get(self.USER_PERMISSIONS_URL + "?email=" + self.CURRENT_USER_EMAIL, headers=self.JWT_HEADERS, verify=settings.VERIFY_REQUESTS).json()
         except JSONDecodeError:
             user_permissions = None
 
         return user_permissions
 
+    # TODO remove
     def current_user_access_requests(self):
 
         try:
@@ -75,6 +77,7 @@ class SciAuthZ:
 
         return user_access_requests
 
+    # TODO remove
     def current_user_request_access(self, access_request):
         try:
             user_access_request = requests.post(self.AUTHORIZATION_REQUEST_URL, headers=self.JWT_HEADERS, data=json.dumps(access_request), verify=settings.VERIFY_REQUESTS)
@@ -83,6 +86,7 @@ class SciAuthZ:
 
         return user_access_request
 
+    # TODO is this creating 3 times over??
     def create_profile_permission(self, grantee_email, project):
         logger.debug('[HYPATIO][create_profile_permission] - Creating Profile Permissions')
 

--- a/app/projects/migrations/0052_auto_20180813_1928.py
+++ b/app/projects/migrations/0052_auto_20180813_1928.py
@@ -9,18 +9,21 @@ def create_n2c2t1_submission_type(apps, schema_editor):
     DataProject = apps.get_model("projects", "dataproject")
     DataProjectSubmissionType = apps.get_model("projects", "dataprojectsubmissiontype")
 
-    n2c2t1_project = DataProject.objects.get(project_key="n2c2-t1")
+    try:
+        n2c2t1_project = DataProject.objects.get(project_key="n2c2-t1")
 
-    DataProjectSubmissionType.objects.create(
-        data_project=n2c2t1_project,
-        title='Task',
-        description='',
-        submission_form_file_path='n2c2-t1.html',
-        max_submissions=3,
-        opened_time=None,
-        closed_time=None,
-        enabled=True,
-    )
+        DataProjectSubmissionType.objects.create(
+            data_project=n2c2t1_project,
+            title='Task',
+            description='',
+            submission_form_file_path='n2c2-t1.html',
+            max_submissions=3,
+            opened_time=None,
+            closed_time=None,
+            enabled=True,
+        )
+    except Exception:
+        pass
 
 
 def convert_dataprojectsubmissions(apps, schema_editor):
@@ -32,13 +35,16 @@ def convert_dataprojectsubmissions(apps, schema_editor):
     DataProjectSubmissionType = apps.get_model("projects", "dataprojectsubmissiontype")
     DataProjectSubmission = apps.get_model("projects", "dataprojectsubmission")
 
-    n2c2t1_project = DataProject.objects.get(project_key="n2c2-t1")
-    n2c2t1_submissiontype = DataProjectSubmissionType.objects.get(data_project=n2c2t1_project)
+    try:
+        n2c2t1_project = DataProject.objects.get(project_key="n2c2-t1")
+        n2c2t1_submissiontype = DataProjectSubmissionType.objects.get(data_project=n2c2t1_project)
 
-    # Set the submission type for every submission
-    for submission in DataProjectSubmission.objects.all():
-        submission.dataprojectsubmissiontype = n2c2t1_submissiontype
-        submission.save()
+        # Set the submission type for every submission
+        for submission in DataProjectSubmission.objects.all():
+            submission.dataprojectsubmissiontype = n2c2t1_submissiontype
+            submission.save()
+    except Exception:
+        pass
 
 
 class Migration(migrations.Migration):

--- a/app/projects/migrations/0055_auto_20180814_1538.py
+++ b/app/projects/migrations/0055_auto_20180814_1538.py
@@ -12,6 +12,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # For some reason, this migration error will occur:
+        #   "Unknown column 'dataprojectsubmission_id' in 'projects_teamsubmissionsdownload_participant_submissions'"
+        # To resolve this, rename the column before renaming the model. Requires sqlparse library installed.
+        migrations.RunSQL(
+            "ALTER TABLE projects_teamsubmissionsdownload_participant_submissions CHANGE COLUMN participantsubmission_id dataprojectsubmission_id char(32);"
+        ),
         migrations.RenameModel(
             old_name='DataProjectSubmission',
             new_name='ChallengeTaskSubmission',

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,3 +18,4 @@ PyJWT==1.6.1
 PyMySQL==0.7.9
 raven==6.1.0
 requests==2.11.1
+sqlparse==0.2.4


### PR DESCRIPTION
For some reason, a column name was not updated in an intermediary table of a manytomanyfield when the related model was renamed. I couldn't find out why Django fails to update the column name when the model was renamed, so instead I am using raw SQL in a migration file to accomplish this.