### PR TITLE
HYP-78: Add a request access button

### DIFF
--- a/app/projects/api.py
+++ b/app/projects/api.py
@@ -603,10 +603,22 @@ def save_signed_external_agreement_form(request):
 def submit_user_permission_request(request):
     """
     An HTTP POST endpoint to handle a request by a user that wants to access a project.
+    Should only be used for projects that do not require teams but do require authorization.
     """
 
-    # TODO Update this to create a new permission request record
-    # ...
+    try:
+        project_key = request.POST.get('project_key', None)
+        project = DataProject.objects.get(project_key=project_key)
+    except ObjectDoesNotExist:
+        return HttpResponse(404)
 
-    # TODO Not implemented
-    return HttpResponse(500)
+    if project.has_teams or not project.requires_authorization:
+        return HttpResponse(400)
+
+    # Create a new participant record if one does not exist already.
+    participant = Participant.objects.get_or_create(
+        user=request.user,
+        data_challenge=project
+    )
+
+    return HttpResponse(200)

--- a/app/projects/views.py
+++ b/app/projects/views.py
@@ -251,9 +251,8 @@ class DataProjectView(TemplateView):
         # Show JWT step (if needed).
         self.setup_panel_show_jwt(context)
 
-        # TODO commented out until this is ready.
         # Access request step (if needed).
-        # self.setup_panel_request_access(context)
+        self.setup_panel_request_access(context)
 
         # Team setup step (if needed).
         self.setup_panel_team(context)
@@ -464,35 +463,30 @@ class DataProjectView(TemplateView):
 
         context['setup_panels'].append(panel)
 
-    # TODO REFACTOR THIS
     def setup_panel_request_access(self, context):
         """
         Builds the context needed for users to request access to a DataProject.
         This is an optional step depending on the DataProject.
         """
 
-        # -----------------------------------------------------------
-        # TODO If RequireAuthorization is True but user does not have VIEW permissions, display this.
-        # -----------------------------------------------------------
-
-        # Only display this step if it is a private data set with no agreement forms
-        if not (self.project.requires_authorization and self.project.agreement_forms.count() == 0):
+        # Only display this step if it is a private data set and the project does not use teams.
+        if not self.project.requires_authorization or self.project.has_teams:
             return
 
-        # TODO Check for access 
-        # access_requested = self.has_user_requested_access(user_access_requests)
-        access_requested = False
-
-        # TODO never completed?
         # This step is never completed, it is usually the last step.
         step_status = self.get_step_status(context['current_step'], 'request_access', False)
+
+        # If the user does not have a participant record, they have not yet requested access.
+        requested_access = self.participant is not None
 
         panel = DataProjectSignupPanel(
             title='Request Access',
             bootstrap_color='default',
             template='projects/signup/request-access.html',
             status=step_status,
-            additional_context={'access_requested': access_requested}
+            additional_context={
+                'requested_access': requested_access
+            }
         )
 
         context['setup_panels'].append(panel)
@@ -518,7 +512,6 @@ class DataProjectView(TemplateView):
                 team_approved=False
             )
 
-        # TODO never completed?
         # This step is never completed.
         step_status = self.get_step_status(context['current_step'], 'setup_team', False)
 

--- a/app/templates/projects/project.html
+++ b/app/templates/projects/project.html
@@ -135,25 +135,4 @@
         });
     });
 </script>
-
-<script type="application/javascript">
-    $('form[name=user_permission_request_form]').submit(function(e){
-        e.preventDefault();
-
-        var submit_button = $(this).find("#submit_user_permission_request");
-
-        $.post($(this).attr('action'), $(this).serialize(), function(res){
-            // $("#loading").hide();
-        }).done(function() {
-            notify('success', "Permission request submitted!", 'thumbs-up');
-
-            // Refresh the page so the user does not see this button again
-            setTimeout(function(){
-                window.location = window.location.pathname
-            },1000);
-        }).fail(function() {
-            submit_button.replaceWith("<h3><span class='label label-danger'>Request failed. Please try again in a few minutes.</span></h3>");            
-        });
-    });
-</script>
 {% endblock %}

--- a/app/templates/projects/signup/request-access.html
+++ b/app/templates/projects/signup/request-access.html
@@ -1,25 +1,35 @@
 {% load static %}
 
-{% if step.access_requested %}
+{% if panel.additional_context.requested_access %}
     Your request is being reviewed. Please use the 'Contact Us' link for any further questions.
 {% else %}
-    <form name="dua_access_form" action="/projects/submit_user_permission_request/" method="post">
-        <input type="hidden" id="project_key" name="project_key" value="{{ step.project }}" />
-        In order to gain access to this data an administrator will have to contact you with further steps. Click below to confirm your request. <br /><br />
-
-        <button type="submit" class="btn btn-primary" disabled>Request Access (COMING SOON)</button>
-        <input type="hidden" id="dua_id" name="dua_id" value="" />
-        <input type="hidden" id="agreement_text" name="agreement_text" value="" />
-
-        <img name="loading" id="loading" src="{% static 'gears.svg' %}" style="display:none;">
-        <div id="status" style="color: green; font-size: 1.5em;"></div>
-
+    <!-- TODO PUT REAL URL -->
+    <form name="access_request_form" action="/projects/submit_user_permission_request/" method="post">
+        <fieldset>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="form-group">
+                        <input type="hidden" id="project_key" name="project_key" value="{{ project.project_key }}" />
+                        To gain access to this dataset, an administrator will review any agreement forms you have signed and may follow up with you for additional information. Please click below to confirm your request.
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="form-group">
+                            <button type="submit" class="btn btn-primary">Request Access</button>
+                            <img name="loading" id="loading" src="{% static 'gears.svg' %}" style="display:none;">
+                            <div id="status" style="color: green; font-size: 1.5em;"></div>
+                    </div>
+                </div>
+            </div>
+        </fieldset>
         {% csrf_token %}
     </form>
 {% endif %}
 
 <script type="application/javascript">
-    $('form[name=dua_access_form]').submit(function(e){
+    $('form[name=access_request_form]').submit(function(e){
         e.preventDefault();
 
         $("#loading").show();


### PR DESCRIPTION
For projects where there are no teams and where authorization is required, display a step for uses to request access after they've completed the earlier steps. This creates a participant record, where then an administrator can approve them for access by creating a VIEW permission in dbmi-authz.