### PR TITLE
HYP-160: Remove grant access buttons if project has teams

### DIFF
--- a/app/manage/api.py
+++ b/app/manage/api.py
@@ -479,6 +479,15 @@ def set_team_status(request):
     sciauthz = SciAuthZ(settings.AUTHZ_BASE, user_jwt, user.email)
     is_manager = sciauthz.user_has_manage_permission(project.project_key)
 
+    logger.debug(
+        '[HYPATIO][DEBUG][set_team_status] User {email} is attempting to set team {team} to status of {status} for project {project_key}.'.format(
+            email=request.user.email,
+            team=team_leader,
+            status=status,
+            project_key=project.project_key
+        )
+    )
+
     if not is_manager:
         logger.debug(
             '[HYPATIO][DEBUG][set_team_status] User {email} does not have MANAGE permissions for item {project_key}.'.format(
@@ -543,7 +552,13 @@ def delete_team(request):
     team_leader = request.POST.get("team")
     administrator_message = request.POST.get("administrator_message")
 
-    logger.debug('[HYPATIO][delete_team] ' + request.user.email + ' is deleting team ' + team_leader + ' for project ' + project_key + '.')
+    logger.debug(
+        '[HYPATIO][DEBUG][delete_team] User {email} is deleting team {team} for project {project_key}.'.format(
+            email=request.user.email,
+            team=team_leader,
+            project_key=project_key
+        )
+    )
 
     project = DataProject.objects.get(project_key=project_key)
 
@@ -784,7 +799,21 @@ def grant_view_permission(request, project_key, user_email):
     sciauthz = SciAuthZ(settings.AUTHZ_BASE, user_jwt, request.user.email)
     is_manager = sciauthz.user_has_manage_permission(project_key)
 
+    logger.debug(
+        '[HYPATIO][DEBUG][grant_view_permission] User {user} is attempting to grant VIEW permissions to participant {participant} for project {project_key}.'.format(
+            user=request.user.email,
+            participant=user_email,
+            project_key=project_key
+        )
+    )
+
     if not is_manager:
+        logger.error(
+            '[HYPATIO][DEBUG][grant_view_permission] User {user} does not have manage permissions to project {project_key}.'.format(
+                user=request.user.email,
+                project_key=project_key
+            )
+        )
         return HttpResponse("Access denied.", status=403)
 
     sciauthz.create_view_permission(project_key, user_email)
@@ -823,7 +852,21 @@ def remove_view_permission(request, project_key, user_email):
     sciauthz = SciAuthZ(settings.AUTHZ_BASE, user_jwt, request.user.email)
     is_manager = sciauthz.user_has_manage_permission(project_key)
 
+    logger.debug(
+        '[HYPATIO][DEBUG][remove_view_permission] User {user} is attempting to remove VIEW permissions from participant {participant} for project {project_key}.'.format(
+            user=request.user.email,
+            participant=user_email,
+            project_key=project_key
+        )
+    )
+
     if not is_manager:
+        logger.error(
+            '[HYPATIO][DEBUG][remove_view_permission] User {user} does not have manage permissions to project {project_key}.'.format(
+                user=request.user.email,
+                project_key=project_key
+            )
+        )
         return HttpResponse("Access denied.", status=403)
 
     sciauthz.remove_view_permission(project_key, user_email)

--- a/app/projects/views.py
+++ b/app/projects/views.py
@@ -715,6 +715,10 @@ class DataProjectView(TemplateView):
             if self.participant is None:
                 return False
 
+            # Make sure the user is on a team.
+            if self.participant.team is None:
+                return False
+
             # Make sure the team leader has accepted this user onto their team.
             if not self.participant.team_approved:
                 return False

--- a/app/templates/manage/project-base.html
+++ b/app/templates/manage/project-base.html
@@ -303,9 +303,13 @@
                                         </button>
                                     {% else %}
                                         {% if participant_info.signed_accepted_agreement_forms == num_required_forms %}
-                                            <button type="button" class="btn btn-default btn-xs btn-success" ic-post-to="{% url 'manage:grant-view-permission' project.project_key participant_info.participant.user.email %}" ic-replace-target="true">
-                                                Grant access <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
-                                            </button>
+                                            {% if not project.has_teams %}
+                                                <button type="button" class="btn btn-default btn-xs btn-success" ic-post-to="{% url 'manage:grant-view-permission' project.project_key participant_info.participant.user.email %}" ic-replace-target="true">
+                                                    Grant access <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
+                                                </button>
+                                            {% else %}
+                                                Grant approval via team management.
+                                            {% endif %}
                                         {% else %}
                                             Forms incomplete or pending your review
                                         {% endif %}

--- a/app/templates/manage/team.html
+++ b/app/templates/manage/team.html
@@ -187,9 +187,14 @@
                                     </button>
                                 {% else %}
                                     {% if member.signed_accepted_agreement_forms == num_required_forms %}
-                                        <button type="button" class="btn btn-default btn-xs btn-success" ic-post-to="{% url 'manage:grant-view-permission' project.project_key member.email %}" ic-replace-target="true">
-                                            Grant access <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
-                                        </button>
+                                        {# Only allow approval of individuals if the team itself is approved #}
+                                        {% if team.status == 'Active' %}
+                                            <button type="button" class="btn btn-default btn-xs btn-success" ic-post-to="{% url 'manage:grant-view-permission' project.project_key member.email %}" ic-replace-target="true">
+                                                Grant access <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
+                                            </button>
+                                        {% else %}
+                                            Grant approval by Approving the team above.
+                                        {% endif %}
                                     {% else %}
                                         Forms incomplete or pending your review
                                     {% endif %}


### PR DESCRIPTION
Adds additional debugging statements. Fixes bug where team_pending and team_approved fields were mispelt and thus never set to False after leaving a team. Fixes another bug where access checking failed if a person had a participant record but no team. Hides grant access button if person is on an unapproved team.